### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/jobs/flag_toxic_post.rb
+++ b/jobs/flag_toxic_post.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class FlagToxicPost < Jobs::Base
+  class FlagToxicPost < ::Jobs::Base
     def execute(args)
       raise Discourse::InvalidParameters.new(:post_id) unless args[:post_id].present?
 

--- a/jobs/inspect_toxic_post.rb
+++ b/jobs/inspect_toxic_post.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class InspectToxicPost < Jobs::Scheduled
+  class InspectToxicPost < ::Jobs::Scheduled
     every 10.minutes
 
     BATCH_SIZE = 1000


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364