### PR TITLE
FIX: Prevent double-posting and errors due to big chunks of text

### DIFF
--- a/lib/discourse_perspective.rb
+++ b/lib/discourse_perspective.rb
@@ -14,11 +14,10 @@ module DiscoursePerspective
     end
 
     def to_json
-      # This is a hard limit from Google API. (3000 bytes)
-      # Truncate naively here. Some long posts are PM and from Discourse.
-      # https://github.com/conversationai/perspectiveapi/blob/master/api_reference.md#scoring-comments-analyzecomment
-      raw = @post.raw[0..3000]
-      while raw.bytesize > 3000
+      # This is a hard limit from Google API. (20000 bytes)
+      # https://github.com/conversationai/perspectiveapi/blob/master/2-api/limits.md#character-limit-for-requests
+      raw = @post.raw
+      while raw.bytesize > 20.kilobytes
         raw = raw[0..-5]
       end
       payload = {

--- a/plugin.rb
+++ b/plugin.rb
@@ -32,7 +32,7 @@ after_initialize do
     class PostToxicityController < ::ApplicationController
       requires_plugin PLUGIN_NAME
 
-      def show
+      def post_toxicity
         if current_user
           RateLimiter.new(current_user, "post-toxicity", 8, 1.minute).performed!
         else
@@ -66,7 +66,7 @@ after_initialize do
   end
 
   Perspective::Engine.routes.draw do
-    get 'post_toxicity' => 'post_toxicity#show'
+    post 'post_toxicity' => 'post_toxicity#post_toxicity'
   end
 
   Discourse::Application.routes.append do

--- a/spec/requests/post_toxicity_controller_spec.rb
+++ b/spec/requests/post_toxicity_controller_spec.rb
@@ -16,26 +16,24 @@ describe ::Perspective::PostToxicityController do
     { "ACCEPT" => "applicaiton/json", "HTTP_ACCEPT" => "application/json" }
   end
 
-  let(:post) { Fabricate(:post, user: log_in) }
-
   describe '.show' do
     it 'returns the score if above threshold' do
       stub_request(:post, api_endpoint).to_return(status: 200, body: api_response_high_toxicity_body, headers: {})
-      get '/perspective/post_toxicity', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
+      post '/perspective/post_toxicity.json', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
       json = JSON.parse(response.body)
       expect(json['score']).to eq 0.915122943
     end
 
     it 'returns nothing if under threshold' do
       stub_request(:post, api_endpoint).to_return(status: 200, body: api_response_toxicity_body, headers: {})
-      get '/perspective/post_toxicity', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
+      post '/perspective/post_toxicity.json', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
       json = JSON.parse(response.body)
       expect(json).to eq({})
     end
 
     it 'returns nothing if any network errors' do
       stub_request(:post, api_endpoint).to_return(status: 403)
-      get '/perspective/post_toxicity', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
+      post '/perspective/post_toxicity.json', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
       json = JSON.parse(response.body)
       expect(json).to eq({})
     end


### PR DESCRIPTION
This PR fixes multiples issues:
- Correctly disables the composer submit button while the perspective API analyzes the post, preventing multiple submissions.
- Sends the post contents inside the body of the request instead of the URL. Large chunks of text were failing because of the URL being too long.
- Increases the size limit to 20000 bytes.