### PR TITLE
FIX: Don't disable the submit button if the post can't be submitted.

### DIFF
--- a/assets/javascripts/initializers/discourse-perspective.js.es6
+++ b/assets/javascripts/initializers/discourse-perspective.js.es6
@@ -22,12 +22,13 @@ function initialize(api) {
         this.set("model.isWarning", false);
       }
 
-      // disable composer submit during perspective validation
-      this.set("disableSubmit", true);
       const composer = this.model;
       if (composer.cantSubmitPost) {
         this.set("lastValidatedAt", Date.now());
         return;
+      } else {
+        // disable composer submit during perspective validation
+        this.set("disableSubmit", true);
       }
 
       const bypassPM =
@@ -37,15 +38,19 @@ function initialize(api) {
         !siteSettings.perspective_check_secured_categories &&
         this.get("model.category.read_restricted");
       const bypassCheck = bypassPM || bypassSecuredCategories;
+
       if (!bypassCheck && !this._perspective_checked) {
         var concat = "";
+
         ["title", "raw", "reply"].forEach((item) => {
           const content = composer.get(item);
           if (content) {
             concat += `${content} `;
           }
         });
+
         concat.trim();
+
         ajax("/perspective/post_toxicity", {
           type: "POST",
           data: { concat: concat },


### PR DESCRIPTION
Previously, we disabled the submit button and did an early return if the `composer.cantSubmitPost` was true. Because of this, we never enabled it again, even if the user fixed the errors.

With this commit, we'll only disable the submit button if the user can submit the post. Otherwise, we'll just bump the `lastValidatedAt` attribute and return.