### PR TITLE
FIX: Promise finally error for perspectiveSave

### DIFF
--- a/assets/javascripts/initializers/discourse-perspective.js
+++ b/assets/javascripts/initializers/discourse-perspective.js
@@ -11,9 +11,19 @@ function initialize(api) {
 
     perspectiveSave(force) {
       this.set("_perspective_checked", true);
-      this.save(force).finally(() => {
+      const result = this.save(force);
+
+      // it's valid for save() to return null since we do that in core,
+      // handle that here because sometimes we return a promise
+      if (result != null && typeof result.then === "function") {
+        result.finally(() => {
+          this.set("disableSubmit", false);
+          this.set("_perspective_checked", false);
+        });
+      } else {
+        this.set("disableSubmit", false);
         this.set("_perspective_checked", false);
-      });
+      }
     },
 
     save(force) {
@@ -43,53 +53,57 @@ function initialize(api) {
       const bypassCheck = bypassPM || bypassSecuredCategories;
 
       if (!bypassCheck && !this._perspective_checked) {
-        let concat = "";
-
-        ["title", "raw", "reply"].forEach((item) => {
-          const content = composer.get(item);
-          if (content) {
-            concat += `${content} `;
-          }
-        });
-
-        concat.trim();
-
-        ajax("/perspective/post_toxicity", {
-          type: "POST",
-          data: { concat },
-        })
-          .then((response) => {
-            if (response && response["score"] !== undefined) {
-              const message = I18n.t("perspective.perspective_message");
-
-              let buttons = [
-                {
-                  label: I18n.t("perspective.composer_continue"),
-                  class: "btn",
-                  callback: () => this.perspectiveSave(force),
-                },
-                {
-                  label: I18n.t("perspective.composer_edit"),
-                  class: "btn-primary",
-                  callback: () => {
-                    this.set("disableSubmit", false);
-                  },
-                },
-              ];
-              bootbox.dialog(message, buttons);
-              return;
-            } else {
-              this.perspectiveSave(force);
-            }
-          })
-          .catch(() => {
-            // fail silently
-            this.perspectiveSave(force);
-          });
+        return this.perspectiveCheckToxicity(composer, force);
       } else {
         this.set("disableSubmit", false);
         return this._super(force);
       }
+    },
+
+    perspectiveCheckToxicity(composer, force) {
+      let concat = "";
+
+      ["title", "raw", "reply"].forEach((item) => {
+        const content = composer.get(item);
+        if (content) {
+          concat += `${content} `;
+        }
+      });
+
+      concat.trim();
+
+      return ajax("/perspective/post_toxicity", {
+        type: "POST",
+        data: { concat },
+      })
+        .then((response) => {
+          if (response && response["score"] !== undefined) {
+            const message = I18n.t("perspective.perspective_message");
+
+            let buttons = [
+              {
+                label: I18n.t("perspective.composer_continue"),
+                class: "btn perspective-continue-post",
+                callback: () => this.perspectiveSave(force),
+              },
+              {
+                label: I18n.t("perspective.composer_edit"),
+                class: "btn-primary perspective-edit-post",
+                callback: () => {
+                  this.set("disableSubmit", false);
+                },
+              },
+            ];
+            bootbox.dialog(message, buttons);
+            return;
+          } else {
+            this.perspectiveSave(force);
+          }
+        })
+        .catch(() => {
+          // fail silently
+          this.perspectiveSave(force);
+        });
     },
   });
 }

--- a/spec/requests/post_toxicity_controller_spec.rb
+++ b/spec/requests/post_toxicity_controller_spec.rb
@@ -19,21 +19,21 @@ describe ::Perspective::PostToxicityController do
   describe '.show' do
     it 'returns the score if above threshold' do
       stub_request(:post, api_endpoint).to_return(status: 200, body: api_response_high_toxicity_body, headers: {})
-      post '/perspective/post_toxicity.json', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
+      post '/perspective/post_toxicity.json', params: { concat: 'everyone is a doo-doo head!' }, headers: headers
       json = JSON.parse(response.body)
       expect(json['score']).to eq 0.915122943
     end
 
     it 'returns nothing if under threshold' do
       stub_request(:post, api_endpoint).to_return(status: 200, body: api_response_toxicity_body, headers: {})
-      post '/perspective/post_toxicity.json', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
+      post '/perspective/post_toxicity.json', params: { concat: 'everyone is a doo-doo head!' }, headers: headers
       json = JSON.parse(response.body)
       expect(json).to eq({})
     end
 
     it 'returns nothing if any network errors' do
       stub_request(:post, api_endpoint).to_return(status: 403)
-      post '/perspective/post_toxicity.json', params: { concat: 'Fuck. This is outrageous and dumb. Go to hell.' }, headers: headers
+      post '/perspective/post_toxicity.json', params: { concat: 'everyone is a doo-doo head!' }, headers: headers
       json = JSON.parse(response.body)
       expect(json).to eq({})
     end

--- a/test/javascripts/acceptance/perspective-test.js
+++ b/test/javascripts/acceptance/perspective-test.js
@@ -2,36 +2,73 @@ import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
-acceptance("Discourse Perspective", function (needs) {
+acceptance(
+  "Discourse Perspective | Enabled | Toxic Post Score",
+  function (needs) {
+    needs.user();
+    needs.settings({
+      perspective_notify_posting_min_toxicity_enable: true,
+      perspective_enabled: true,
+    });
+
+    needs.pretender((server, helper) => {
+      server.post("/perspective/post_toxicity", () => {
+        return helper.response({ success: "OK", score: 0.99 });
+      });
+    });
+
+    test("Create a toxic topic and click edit before continuing", async function (assert) {
+      await visit("/");
+      await click("#create-topic");
+
+      await fillIn("#reply-title", "this is a normal title");
+      await fillIn(".d-editor-input", "everyone is a doo-doo head!");
+
+      await click("#reply-control button.create");
+
+      await click(".perspective-edit-post");
+      assert.notOk(
+        exists(".cooked"),
+        "new topic was not created, composer is still open"
+      );
+    });
+
+    test("Create a toxic topic and click continue with post creation", async function (assert) {
+      await visit("/");
+      await click("#create-topic");
+
+      await fillIn("#reply-title", "this is a normal title");
+      await fillIn(".d-editor-input", "everyone is a doo-doo head!");
+
+      await click("#reply-control button.create");
+
+      await click(".perspective-continue-post");
+      assert.ok(exists(".cooked"), "new topic created");
+    });
+  }
+);
+
+acceptance("Discourse Perspective | Enabled | No Post Score", function (needs) {
   needs.user();
   needs.settings({
     perspective_notify_posting_min_toxicity_enable: true,
+    perspective_enabled: true,
   });
 
-  test("Create a normal topic", async function (assert) {
+  needs.pretender((server, helper) => {
+    server.post("/perspective/post_toxicity", () => {
+      return helper.response({ success: "OK" });
+    });
+  });
+
+  test("Create a topic without issues", async function (assert) {
     await visit("/");
     await click("#create-topic");
 
     await fillIn("#reply-title", "this is a normal title");
-    await fillIn(".d-editor-input", "hello world! This is a normal topic");
+    await fillIn(".d-editor-input", "everyone is a doo-doo head!");
 
     await click("#reply-control button.create");
-
-    assert.ok(exists(".cooked"), "new topic created");
-  });
-
-  test("Create a toxic topic without api keys filled", async function (assert) {
-    await visit("/");
-    await click("#create-topic");
-
-    await fillIn("#reply-title", "this is a normal title");
-    await fillIn(
-      ".d-editor-input",
-      "Fuck. This is outrageous and dumb. Go to hell."
-    );
-
-    await click("#reply-control button.create");
-
     assert.ok(exists(".cooked"), "new topic created");
   });
 });


### PR DESCRIPTION
There are some cases when the .save() call within
.perspectiveSave() would return null instead of a promise,
causing an error. We return null sometimes in core from
this function, so we just check whether the result is null
or a promise and act accordingly.

Also adds some tests and does some minor refactoring.

c.f. https://meta.discourse.org/t/javascript-error-in-google-perspective-api-plugin/226732