### PR TITLE
FIX: prevents test failure when using set on destroyed

### DIFF
--- a/assets/javascripts/initializers/discourse-perspective.js
+++ b/assets/javascripts/initializers/discourse-perspective.js
@@ -90,6 +90,10 @@ function initialize(api) {
                 label: I18n.t("perspective.composer_edit"),
                 class: "btn-primary perspective-edit-post",
                 callback: () => {
+                  if (this.isDestroying || this.isDestroyed) {
+                    return;
+                  }
+
                   this.set("disableSubmit", false);
                 },
               },


### PR DESCRIPTION
Repro:

- `/tests?hidepassed=1&qunit_skip_core=1&seed=232445140220376764190994500674877650826`

Example error:

```
Error: Assertion Failed: calling set on destroyed object: <(unknown):ember14289>.disableSubmit = false
```