### PR TITLE
DEV: ensures we check at runtime if enabled

### DIFF
--- a/assets/javascripts/initializers/discourse-perspective.js
+++ b/assets/javascripts/initializers/discourse-perspective.js
@@ -2,6 +2,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { ajax } from "discourse/lib/ajax";
 import I18n from "I18n";
 import bootbox from "bootbox";
+import { isTesting } from "discourse-common/config/environment";
 
 function initialize(api) {
   const siteSettings = api.container.lookup("site-settings:main");
@@ -27,6 +28,10 @@ function initialize(api) {
     },
 
     save(force) {
+      if (!this.siteSettings.perspective_enabled) {
+        return this._super(...arguments);
+      }
+
       // same validation code from controller
       if (this.disableSubmit && !this._perspective_checked) {
         return;

--- a/assets/javascripts/initializers/discourse-perspective.js
+++ b/assets/javascripts/initializers/discourse-perspective.js
@@ -2,7 +2,6 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { ajax } from "discourse/lib/ajax";
 import I18n from "I18n";
 import bootbox from "bootbox";
-import { isTesting } from "discourse-common/config/environment";
 
 function initialize(api) {
   const siteSettings = api.container.lookup("site-settings:main");


### PR DESCRIPTION
This is a common source of issues:

- a test using setting perspective_enabled is ran as a result the initialiser runs and modifyClass happens
- another test not expecting perspective_enabled is run, and even if the initializer won't run again, the class has already been modified
- :boom: