### PR TITLE
FIX: Add nil check for topic

### DIFF
--- a/lib/discourse_perspective.rb
+++ b/lib/discourse_perspective.rb
@@ -163,7 +163,7 @@ module DiscoursePerspective
     # default not to check secured categories
     return false if !SiteSetting.perspective_check_secured_categories && post&.topic&.category&.read_restricted?
     # don't check trashed topics
-    return false if post&.topic.trashed?
+    return false if post&.topic&.trashed?
 
     stripped = post.raw.strip
 

--- a/lib/discourse_perspective.rb
+++ b/lib/discourse_perspective.rb
@@ -163,7 +163,7 @@ module DiscoursePerspective
     # default not to check secured categories
     return false if !SiteSetting.perspective_check_secured_categories && post&.topic&.category&.read_restricted?
     # don't check trashed topics
-    return false if post&.topic&.trashed?
+    return false if !post.topic || post.topic.trashed?
 
     stripped = post.raw.strip
 


### PR DESCRIPTION
Not sure why, but our site keeps logging an error about topic being nil, so added a nil check for it.