### PR TITLE
DEV: Fix JS tests to use default site settings

### DIFF
--- a/test/javascripts/acceptance/perspective-test.js
+++ b/test/javascripts/acceptance/perspective-test.js
@@ -1,4 +1,5 @@
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
@@ -20,6 +21,9 @@ acceptance(
     test("Create a toxic topic and click edit before continuing", async function (assert) {
       await visit("/");
       await click("#create-topic");
+      const categoryChooser = selectKit(".category-chooser");
+      await categoryChooser.expand();
+      await categoryChooser.selectRowByValue(2);
 
       await fillIn("#reply-title", "this is a normal title");
       await fillIn(".d-editor-input", "everyone is a doo-doo head!");
@@ -36,6 +40,9 @@ acceptance(
     test("Create a toxic topic and click continue with post creation", async function (assert) {
       await visit("/");
       await click("#create-topic");
+      const categoryChooser = selectKit(".category-chooser");
+      await categoryChooser.expand();
+      await categoryChooser.selectRowByValue(2);
 
       await fillIn("#reply-title", "this is a normal title");
       await fillIn(".d-editor-input", "everyone is a doo-doo head!");
@@ -64,6 +71,9 @@ acceptance("Discourse Perspective | Enabled | No Post Score", function (needs) {
   test("Create a topic without issues", async function (assert) {
     await visit("/");
     await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
 
     await fillIn("#reply-title", "this is a normal title");
     await fillIn(".d-editor-input", "everyone is a doo-doo head!");


### PR DESCRIPTION
In preparation for core PR https://github.com/discourse/discourse/pull/18413 which changes JS to load default yml site settings, the main one needing changes is that now the
allow_uncategorized_topics setting is false
by default, which requires setting the category
in the composer before using it.