### PR TITLE
DEV: Replace deprecated PostAction.act with PostActionCreator.create

### DIFF
--- a/lib/discourse_perspective.rb
+++ b/lib/discourse_perspective.rb
@@ -73,10 +73,10 @@ module DiscoursePerspective
 
   def self.flag_on_scores(score, post)
     if score[:score] > SiteSetting.perspective_flag_post_min_toxicity
-      PostAction.act(
+      PostActionCreator.create(
         Discourse.system_user,
         post,
-        PostActionType.types[:notify_moderators],
+        :notify_moderators,
         message: I18n.t("perspective_flag_message"),
       )
     end

--- a/spec/discourse_perspective_spec.rb
+++ b/spec/discourse_perspective_spec.rb
@@ -135,12 +135,12 @@ describe DiscoursePerspective do
     let(:post) { Fabricate(:post) }
 
     it "acts if threshold exceeded" do
-      PostAction.expects(:act).once
+      PostActionCreator.expects(:create).once
       DiscoursePerspective.flag_on_scores(score, post)
     end
 
     it "does nothing if score is low" do
-      PostAction.expects(:act).never
+      PostActionCreator.expects(:create).never
       DiscoursePerspective.flag_on_scores(zero_score, post)
     end
   end


### PR DESCRIPTION
### What is this change?

`PostAction.act` has been deprecated four years ago, and was marked for removal in 2.9.0. This PR replaces its use with `PostActionCreator.create` which replaces it.