### PR TITLE
DEV: Change settings root from plugins: to discourse_perspective

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_perspective: "Discourse Perspective"
   js:
     perspective:
       perspective_message: "It looks like what you're about to post might be considered rude or disrespectful to others, and may be flagged for review."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_perspective:
   perspective_enabled:
     default: false
     client: true


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.