### PR TITLE
DEV: This line doesn't do anything

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -34,8 +34,6 @@ after_initialize do
     end
   end
 
-  register_post_custom_field_type(DiscoursePerspective.post_score_field_name, :float)
-
   require_dependency "application_controller"
 
   module ::Perspective


### PR DESCRIPTION
:float isn't a recognized option, it just gets interpreted as string, which is the default, and it shouldn't be registering fields, which are global, based on SiteSettings, which are per site anyway.