### PR TITLE
DEV: Remove unused `fakeweb` require

### DIFF
--- a/spec/discourse_perspective_spec.rb
+++ b/spec/discourse_perspective_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "fakeweb"
 
 API_ENDPOINT = "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key="
 API_RESPONSE_TOXICITY_BODY =


### PR DESCRIPTION
This doesn't actually seem to be used by the discourse-perspective specs, but it's causing specs of other plugins to flake out